### PR TITLE
v25.05.01

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+## [v25.05.01] - 2025-06-18
+
+### Added
+  - H100 support for the following recipes
+    - Llama3.1 405B
+    - Grok1 314B
+
+### Changed
+  - Fixed DeepSeek and Llama4 READMEs
+  - Installer
+    - Enforce min and max python versions
+	- Use GRES properly for CPU_PARTITION jobs.
+  - bitsandbytes update for ARM systems.
+
 ## [v25.05] - 2025-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following tables list each benchmark used to evaluate the model's performanc
 | NeMo | Nemotron4 | 25.04.00 | 340B | Pretrain | 128-256 | FP8, BF16 | No | No | Slurm |
 | NeMo | Llama 3.1 | 25.04.01 | 405B | Pretrain | 128-256 | FP8, BF16 | Yes | No | Slurm |
 | NeMo | DeepSeek V3 | 25.04.01 | 671B | Pretrain | 128-256 | BF16 | Yes | No | Slurm |
-| NeMo | Grok1 | 25.04.00 | 314B | Pretrain | 128-256 | FP8, BF16 | No | No | Slurm |
+| NeMo | Grok1 | 25.04.00 | 314B | Pretrain | 128-256 | FP8, BF16 | Yes | No | Slurm |
 | NeMo | Llama4 Maverick | 25.04.01 | 400B | Pretrain | 128-512 | FP8, BF16 | Yes | No | Slurm |
 
 ### H100 Workloads
@@ -139,6 +139,8 @@ Baseline performance metrics were using workloads on the NVIDIA DGX H100 Referen
 | NeMo | DeepSeek V3 | 25.04.01 | 671B | Pretrain | 1024 | BF16 | Yes | No | Slurm |
 | NeMo | Llama4 Maverick | 25.04.01 | 400B | Pretrain | 512 | FP8, BF16 | Yes | No | Slurm |
 | NeMo | Nemotron-H | 25.04.01 | 56B | Pretrain | 32-2048 | FP8 | No | No | Slurm |
+| NeMo | Llama 3.1 | 25.04.01 | 405B | Pretrain | 512 | FP8, BF16 | Yes | No | Slurm |
+| NeMo | Grok1 | 25.04.00 | 314B | Pretrain | 512 | FP8, BF16 | Yes | No | Slurm |
 | NIM | Llama 3.1 and 3.2 | instruct:1.3.3, rerank:1.3, embed:1.3.1 | 70b, 1b | Inference | 1-8 | n/a | Yes | No | Slurm |
 | NIM | Llama 3 | 1.0.3 | 70B | Inference | 4 | FP8 | Yes | No | Slurm |
 | NIM | DeepSeek R1 | 1.7.2 | 671B | Inference | 16 | FP8 | Yes | No | Slurm |
@@ -245,26 +247,19 @@ export NCCL_P2P_NET_CHUNKSIZE=2097152
 
 # Release Notes
 
-## Performance Recipes version 25.05
+## Performance Recipes version 25.05.01
 
 ### Added
-  - GB200 support for the following recipes
+  - H100 support for the following recipes
     - Llama3.1 405B
     - Grok1 314B
-    - Nemotron4 15B/340B
-    - Deepseek v3
-    - Llama 4 Maverick
-  - Nemotron-H 56B model training recipe for H100 GPUs
-  - End to end installer and launcher for all recipes
-
 
 ### Changed
-  - Recipes collection moved from [NGC Collection](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/dgxc-benchmarking/collections/dgxc-benchmarking) to [GitHub](https://github.com/NVIDIA/dgxc-benchmarking).
-
-### Removed
-  - NeMo GPT3 175b training recipe in favor of Nemotron4
-  - Maxtext Llama 3 training recipe
-  - Llama 3 SFT/LoRa fine tuning recipes
+  - Fixed DeepSeek and Llama4 READMEs
+  - Installer
+    - Enforce min and max python versions
+    - Use GRES properly for CPU_PARTITION jobs.
+  - bitsandbytes update for ARM systems.
 
 # FAQ
 

--- a/deepseek_v3/pretraining/README.md
+++ b/deepseek_v3/pretraining/README.md
@@ -122,7 +122,7 @@ These parameters can be set either by exporting the environment variable or usin
 
 ## Prepare environment
 
-The recommended way to prepare your environment is to use the **installer** referenced in the [main README](../README.md):
+The recommended way to prepare your environment is to use the **installer** referenced in the [main README](../../README.md):
 
 Note, that a new directory layout and key variables are now used in the recipe:
 
@@ -345,8 +345,8 @@ conda deactivate
 
 To install and activate python venv 
 ```shell
-python3 -m venv $LLMB_INSTALL/venv/<venv_name>
-source $LLMB_INSTALL/venv/<venv_name>/bin/activate
+python3 -m venv $LLMB_INSTALL/venvs/<venv_name>
+source $LLMB_INSTALL/venvs/<venv_name>/bin/activate
 ```
 
 When you are finished running this benchmark you can deactivate the environment, run this command
@@ -356,25 +356,21 @@ deactivate
 
 ### Setup script
 
-Create a install directory by running the attached setup.sh.
+Create a install directory by running the attached setup.sh. The script converts the docker image to a ```.sqsh``` file under the $LLMB_INSTALL/images folder and installs required packages to the python environment to enable NeMo-Run launcher functionality.
 
-***Important***
-
-The setup script must be run while you are in your virtual environment. 
-This script clones the ***NeMo*** repository, installs ***megatron-core*** and ***nemo run***, and installs required packages to the python environment to enable NeMo-Run launcher functionality. 
-
-Be sure to **deactivate** your virtual environment before importing the container image to be used to run the workload. 
+**Important:** Make sure the previous step has been completed and python virtual environment is active. Run the setup script using the following command.
 
 **SLURM:**
 
 ```shell
 # activate virtual python environment setup previously
 ./setup.sh
-# deactivate virtual environment
-srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "enroot import --output ${LLMB_INSTALL}/images/nvidia+nemo+25.04.01.sqsh docker://nvcr.io#nvidia/nemo:25.04.01""
 ```
-***Important***
-The above srun command converts the docker image to a ```.sqsh``` file under the $LLMB_INSTALL/images folder. Your virtual env must be deactivated before running this command. 
+To fetch the image ensure your virtual environment has been **deactivated**, then run:
+
+```shell
+srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "enroot import --output ${LLMB_INSTALL}/images/nvidia+nemo+25.04.01.sqsh docker://nvcr.io#nvidia/nemo:25.04.01"
+``` 
 
 
 **Note**: output log from running `setup.sh` script may include an error about tritonclient dependency. The error can be ignored as it doesn't affect benchmark functionality. 

--- a/deepseek_v3/pretraining/launch.sh
+++ b/deepseek_v3/pretraining/launch.sh
@@ -31,7 +31,7 @@ set -eu -o pipefail
 export WORKLOAD_TYPE=pretraining
 export MODEL_NAME=deepseek_v3
 export FW_VERSION=25.04.01
-export GSW_VERSION=25.05
+export GSW_VERSION=25.05.01
 
 export OPENBLAS_NUM_THREADS=1 # optional, to avoid resource contention at the frontend node.
 

--- a/deepseek_v3/pretraining/metadata.yaml
+++ b/deepseek_v3/pretraining/metadata.yaml
@@ -2,7 +2,7 @@
 general:
   workload: deepseek_v3
   workload_type: pretraining
-  gsw_version: 25.05
+  gsw_version: 25.05.01
   framework: nemo2
 
 container:

--- a/deepseek_v3/pretraining/setup.sh
+++ b/deepseek_v3/pretraining/setup.sh
@@ -70,6 +70,6 @@ popd
 
 # 2. Install dependencies
 pip install 'scipy<1.13.0' # a workaround for compatibility issue
-pip install 'bitsandbytes==0.45.5' # Future NeMo release 25.07/09 will have this fix.
+pip install 'bitsandbytes==0.46.0' # Future NeMo release 25.07/09 will have this fix.
 pip install megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@$MEGATRON_COMMIT
 pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@$NEMO_RUN_COMMIT

--- a/grok1/launch.sh
+++ b/grok1/launch.sh
@@ -32,7 +32,7 @@ set -eu -o pipefail
 export WORKLOAD_TYPE=pretraining
 export MODEL_NAME=grok1
 export FW_VERSION=25.04.00
-export GSW_VERSION=25.05
+export GSW_VERSION=25.05.01
 
 export OPENBLAS_NUM_THREADS=1 # optional, to avoid resource contention at the frontend node.
 export HF_TOKEN=${HF_TOKEN?"Required variable HF_TOKEN"}
@@ -81,7 +81,7 @@ if [ $GPU_TYPE = "gb200" ]; then
   CP=${CP:-1}
   EP=${EP:-8}
   VP=${VP:-1}
-  ET=${ET:-8}
+  ET=${ET:-4}
   GBS=${GBS:-}
   if [ -z "$GBS" ]; then
     GBS=$(( JOB_TOTAL_GPUS * 2 ))
@@ -108,7 +108,7 @@ elif [ $GPU_TYPE = "h100" ]; then
   PP=${PP:-8}
   CP=${CP:-2}
   EP=${EP:-8}
-  VP=${VP:-1}
+  VP=${VP:-8}
   ET=${ET:-1}
   GBS=${GBS:-}
   if [ -z "$GBS" ]; then

--- a/grok1/metadata.yaml
+++ b/grok1/metadata.yaml
@@ -2,7 +2,7 @@
 general:
   workload: grok1
   workload_type: pretraining
-  gsw_version: 25.05
+  gsw_version: 25.05.01
   framework: nemo2
 
 container:
@@ -24,3 +24,9 @@ run:
         - model_size: '314b'
           dtypes: ['fp8', 'bf16']
           scales: [128, 256, 512]
+    h100:
+      model_configs:
+        - model_size: '314b'
+          dtypes: ['fp8', 'bf16']
+          scales: [512]
+

--- a/grok1/setup.sh
+++ b/grok1/setup.sh
@@ -52,9 +52,9 @@ fi
 
 # -------- llmb-nemo commits
 # r2.3.0 llmb-nemo
-export NEMO_COMMIT="7a8f1cc7bc40a84447c0681a9e4e956a135ae8a2"
-export MEGATRON_COMMIT="7094270c6fa1dbc6b2e99072171e3a559ca36d0f"
-export NEMO_RUN_COMMIT="bc412ee5584ed3072717af59f54565ec0d265a6f" #r0.4.0
+export NEMO_COMMIT="6f2c6fdaffcc0af97a9e2219fcc104e2399627e4"
+export MEGATRON_COMMIT="64cb6bd7a155c4e742514ed1024407fb97d0a367"
+export NEMO_RUN_COMMIT="f3e69eebb2bf66e46f6a2aa64465f714f9ea751d"
 
 # 1. Clone the NeMo source code
 #Setup NeMo 
@@ -71,7 +71,7 @@ popd
 
 # 2. Install dependencies
 pip install 'scipy<1.13.0' # a workaround for compatibility issue
-pip install 'bitsandbytes==0.45.5' # Future NeMo release 25.07/09 will have this fix.
+pip install 'bitsandbytes==0.46.0' # Future NeMo release 25.07/09 will have this fix.
 pip install megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@$MEGATRON_COMMIT
 pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@$NEMO_RUN_COMMIT
 

--- a/llama3.1/metadata.yaml
+++ b/llama3.1/metadata.yaml
@@ -2,7 +2,7 @@
 general:
   workload: llama3.1
   workload_type: pretraining
-  gsw_version: 25.05
+  gsw_version: 25.05.01
   framework: nemo2
 
 container:
@@ -24,4 +24,9 @@ run:
         - model_size: '405b'
           dtypes: ['fp8', 'bf16']
           scales: [128, 256, 512]
+    h100:
+      model_configs:
+        - model_size: '405b'
+          dtypes: ['fp8', 'bf16']
+          scales: [512]
   

--- a/llama3.1/setup.sh
+++ b/llama3.1/setup.sh
@@ -51,9 +51,9 @@ fi
 
 # -------- llmb-nemo commits
 # r2.3.0 llmb-nemo
-export NEMO_COMMIT="7a8f1cc7bc40a84447c0681a9e4e956a135ae8a2"
-export MEGATRON_COMMIT="7094270c6fa1dbc6b2e99072171e3a559ca36d0f"
-export NEMO_RUN_COMMIT="78f54ee182c8057bbe35872e49459c17458b669e"
+export NEMO_COMMIT="6f2c6fdaffcc0af97a9e2219fcc104e2399627e4"
+export MEGATRON_COMMIT="64cb6bd7a155c4e742514ed1024407fb97d0a367"
+export NEMO_RUN_COMMIT="f3e69eebb2bf66e46f6a2aa64465f714f9ea751d"
 
 # 1. Clone the NeMo source code
 #Setup NeMo 
@@ -69,7 +69,7 @@ popd
 
 # 2. Install dependencies
 pip install 'scipy<1.13.0' # a workaround for compatibility issue
-pip install 'bitsandbytes==0.45.5' # Future NeMo release 25.07/09 will have this fix.
+pip install 'bitsandbytes==0.46.0' # Future NeMo release 25.07/09 will have this fix.
 pip install megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@$MEGATRON_COMMIT
 pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@$NEMO_RUN_COMMIT
 

--- a/llama4/README.md
+++ b/llama4/README.md
@@ -8,15 +8,15 @@ The GB200 jobs listed below progressively increase GPU count, with configuration
 
 |Model Size|Precision | GPUs | SeqLen | Layers | TP  | PP  | CP  | EP  | DP  | VP  |ETP | MBS | GBS  | GA  |
 |:---------|:---------:|:----:|:------:|:------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:----:|:---:|:---:|
-| 400b | BF16/FP8  | 128    | 8192   | 32     | 1   | 2   | 1   | 64  | 64   | 12 | 1  | 1   | 1024  | 16 |
-| 400b | BF16/FP8  | 256    | 8192   | 32     | 1   | 2   | 1   | 64  | 128   | 12 | 1  | 1   | 2048  | 16 |
-| 400b | BF16/FP8  | 512    | 8192   | 32     | 1   | 2   | 1   | 64  | 256   | 12 | 1  | 1   | 4096  | 16 |
+| 400b | BF16/FP8  | 128    | 8192   | 48     | 1   | 2   | 1   | 64  | 64   | 12 | 1  | 1   | 1024  | 16 |
+| 400b | BF16/FP8  | 256    | 8192   | 48     | 1   | 2   | 1   | 64  | 128   | 12 | 1  | 1   | 2048  | 16 |
+| 400b | BF16/FP8  | 512    | 8192   | 48     | 1   | 2   | 1   | 64  | 256   | 12 | 1  | 1   | 4096  | 16 |
 
 **H100 Configs** 
 
 |Model Size|Precision | GPUs | SeqLen | Layers | TP  | PP  | CP  | EP  | DP  | VP | ETP  | MBS | GBS  | GA  |
 |:---------|:---------:|:----:|:------:|:------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:----:|:---:|:---:|
-| 400b | BF16/FP8  | 512    | 8192   | 32     | 4   | 1   | 1   | 128  | 128   | 12  | 4 | 1   | 1024  | 8 |
+| 400b | BF16/FP8  | 512    | 8192   | 48     | 4   | 1   | 1   | 128  | 128   | 12  | 4 | 1   | 1024  | 8 |
 
 
 # Expected Performance
@@ -388,8 +388,8 @@ conda deactivate
 
 To install and activate python venv 
 ```shell
-python3 -m venv $LLMB_INSTALL/venv/<venv_name>
-source $LLMB_INSTALL/venv/<venv_name>/bin/activate
+python3 -m venv $LLMB_INSTALL/venvs/<venv_name>
+source $LLMB_INSTALL/venvs/<venv_name>/bin/activate
 ```
 
 When you are finished running this benchmark you can deactivate the environment, run this command
@@ -401,7 +401,7 @@ deactivate
 
 Create a install directory by running the attached setup.sh. The script converts the docker image to a ```.sqsh``` file under the $LLMB_INSTALL/images folder and installs required packages to the python environment to enable NeMo-Run launcher functionality.
 
-Make sure the previous step has been completed and python virtual environment is active. Run the setup script using the following command.
+**Important:** Make sure the previous step has been completed and python virtual environment is active. Run the setup script using the following command.
 
 **SLURM:**
 
@@ -409,9 +409,9 @@ Make sure the previous step has been completed and python virtual environment is
 # activate virtual python environment setup previously
 ./setup.sh
 ```
-To fetch the image ensure your virtual environment has been deactivated, then run:
+To fetch the image ensure your virtual environment has been **deactivated**, then run:
 
-```
+```shell
 srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "enroot import --output ${LLMB_INSTALL}/images/nvidia+nemo+25.04.01.sqsh docker://nvcr.io#nvidia/nemo:25.04.01"
 ```
 

--- a/llama4/launch.sh
+++ b/llama4/launch.sh
@@ -39,7 +39,7 @@ set -eu -o pipefail
 export WORKLOAD_TYPE=pretraining
 export MODEL_NAME=llama4_maverick
 export FW_VERSION=25.04.01
-export GSW_VERSION=25.05
+export GSW_VERSION=25.05.01
 
 export OPENBLAS_NUM_THREADS=1 # optional, to avoid resource contention at the frontend node.
 

--- a/llama4/metadata.yaml
+++ b/llama4/metadata.yaml
@@ -2,7 +2,7 @@
 general:
   workload: llama4_maverick
   workload_type: pretraining
-  gsw_version: 25.04.01
+  gsw_version: 25.05.01
   framework: nemo2
 
 container:

--- a/llama4/setup.sh
+++ b/llama4/setup.sh
@@ -72,6 +72,6 @@ popd
 
 # 2. Install dependencies
 pip install 'scipy<1.13.0' # a workaround for compatibility issue
-pip install 'bitsandbytes==0.45.5' # Future NeMo release 25.07/09 will have this fix.
+pip install 'bitsandbytes==0.46.0' # Future NeMo release 25.07/09 will have this fix.
 pip install megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@$MEGATRON_COMMIT
 pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@$NEMO_RUN_COMMIT

--- a/nemotron/README.md
+++ b/nemotron/README.md
@@ -487,8 +487,8 @@ conda deactivate
 
 To install and activate python venv 
 ```shell
-python3 -m venv $LLMB_INSTALL/venv/<venv_name>
-source $LLMB_INSTALL/venv/<venv_name>/bin/activate
+python3 -m venv $LLMB_INSTALL/venvs/<venv_name>
+source $LLMB_INSTALL/venvs/<venv_name>/bin/activate
 ```
 
 When you are finished running this benchmark you can deactivate the environment, run this command
@@ -498,27 +498,21 @@ deactivate
 
 ### Setup script
 
-Create a install directory by running the attached setup.sh.
+Create a install directory by running the attached setup.sh. The script converts the docker image to a ```.sqsh``` file under the $LLMB_INSTALL/images folder and installs required packages to the python environment to enable NeMo-Run launcher functionality.
 
-***Important***
-
-The setup script must be run while you are in your virtual environment. 
-This script clones the ***NeMo*** repository, installs ***megatron-core*** and ***nemo run***, and installs required packages to the python environment to enable NeMo-Run launcher functionality. 
-
-Be sure to **deactivate** your virtual environment before importing the container image to be used to run the workload. 
+**Important:** Make sure the previous step has been completed and python virtual environment is active. Run the setup script using the following command.
 
 **SLURM:**
 
 ```shell
 # activate virtual python environment setup previously
-export CLUSTER_TYPE=slurm
-# virtual environment must be active
 ./setup.sh
-# deactivate virtual environment
-srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "enroot import --output ${LLMB_INSTALL}/images/nvidia+nemo+25.04.00.sqsh docker://nvcr.io#nvidia/nemo:25.04.00"
 ```
-***Important***
-The above srun command converts the docker image to a ```.sqsh``` file under the $LLMB_INSTALL/images folder. Your virtual env must be deactivated before running this command. 
+To fetch the image ensure your virtual environment has been **deactivated**, then run:
+
+```shell
+srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "enroot import --output ${LLMB_INSTALL}/images/nvidia+nemo+25.04.00.sqsh docker://nvcr.io#nvidia/nemo:25.04.00"
+``` 
 
 
 **Note**: output log from running `setup.sh` script may include an error about tritonclient dependency. The error can be ignored as it doesn't affect benchmark functionality. 

--- a/nemotron/launch.sh
+++ b/nemotron/launch.sh
@@ -31,7 +31,7 @@ set -eu -o pipefail
 export WORKLOAD_TYPE=pretraining
 export MODEL_NAME=nemotron
 export FW_VERSION=25.04.00
-export GSW_VERSION=25.05
+export GSW_VERSION=25.05.01
 
 export OPENBLAS_NUM_THREADS=1 # optional, to avoid resource contention at the frontend node.
 

--- a/nemotron/metadata.yaml
+++ b/nemotron/metadata.yaml
@@ -2,7 +2,7 @@
 general:
   workload: nemotron
   workload_type: pretraining
-  gsw_version: 25.05
+  gsw_version: 25.05.01
   framework: nemo2
 
 container:

--- a/nemotron/setup.sh
+++ b/nemotron/setup.sh
@@ -69,6 +69,6 @@ popd
 
 # 2. Install dependencies
 pip install 'scipy<1.13.0' # a workaround for compatibility issue
-pip install 'bitsandbytes==0.45.5' # Future NeMo release 25.07/09 will have this fix.
+pip install 'bitsandbytes==0.46.0' # Future NeMo release 25.07/09 will have this fix.
 pip install megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@$MEGATRON_COMMIT
 pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@$NEMO_RUN_COMMIT

--- a/nemotronh/README.md
+++ b/nemotronh/README.md
@@ -367,9 +367,9 @@ deactivate
 
 ### Setup script
 
-The setup script creates the necessary folder hierarchy and installs required packages to the python environment to enable NeMo-Run launcher functionality. It does **not** fetch the image which is a separate step.
+Create a install directory by running the attached setup.sh. The script converts the docker image to a ```.sqsh``` file under the $LLMB_INSTALL/images folder and installs required packages to the python environment to enable NeMo-Run launcher functionality.
 
-Make sure the previous step has been completed and python virtual environment is active. Run the setup script using the following command.
+**Important:** Make sure the previous step has been completed and python virtual environment is active. Run the setup script using the following command.
 
 **SLURM:**
 
@@ -377,8 +377,8 @@ Make sure the previous step has been completed and python virtual environment is
 # activate virtual python environment setup previously
 ./setup.sh
 ```
-
 To fetch the image ensure your virtual environment has been **deactivated**, then run:
+
 ```shell
 srun --account ${SBATCH_ACCOUNT} --partition ${SBATCH_PARTITION} bash -c "enroot import --output ${LLMB_INSTALL}/images/nvidia+nemo+25.04.01.sqsh docker://nvcr.io#nvidia/nemo:25.04.01"
 ```

--- a/nemotronh/launch.sh
+++ b/nemotronh/launch.sh
@@ -31,7 +31,7 @@ set -eu -o pipefail
 export WORKLOAD_TYPE=pretraining
 export MODEL_NAME=nemotronh
 export FW_VERSION=25.04.01
-export GSW_VERSION=25.05
+export GSW_VERSION=25.05.01
 
 export OPENBLAS_NUM_THREADS=1 # optional, to avoid resource contention at the frontend node.
 

--- a/nemotronh/metadata.yaml
+++ b/nemotronh/metadata.yaml
@@ -2,7 +2,7 @@
 general:
   workload: nemotronh
   workload_type: pretraining
-  gsw_version: 25.05
+  gsw_version: 25.05.01
   framework: nemo2
 
 container:

--- a/nemotronh/setup.sh
+++ b/nemotronh/setup.sh
@@ -68,6 +68,6 @@ popd
 
 # 2. Install dependencies
 pip install 'scipy<1.13.0' # a workaround for compatibility issue
-pip install 'bitsandbytes==0.45.5' # Future NeMo release 25.07/09 will have this fix.
+pip install 'bitsandbytes==0.46.0' # Future NeMo release 25.07/09 will have this fix.
 pip install megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@$MEGATRON_COMMIT
 pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@$NEMO_RUN_COMMIT


### PR DESCRIPTION
### Added

- H100 support for the following recipes
  - Llama3.1 405B
  - Grok1 314B

### Changed

- Fixed DeepSeek and Llama4 READMEs
- Installer
  - Enforce min and max python versions
  - Use GRES properly for CPU_PARTITION jobs.
- bitsandbytes update for ARM systems.