### PR TITLE
Fix #5 [BUG] Gres config doesn't translate to the sbatch file

### DIFF
--- a/llmb-run/README.md
+++ b/llmb-run/README.md
@@ -264,7 +264,7 @@ For comprehensive examples of both simple and complex configurations, see the [B
 
 5. **Job Submission Fails**
    - Check your Slurm account and partition settings in `cluster_config.yaml`
-   - If your system does not support GRES, make sure `SBATCH_GPUS_PER_NODE` is not in your environment section
+   - If your system does not support GRES, make sure `SLURM_GPUS_PER_NODE` is not in your environment section
    - Use `-v` flag for verbose output to see detailed error messages
 
 ## Alternative Installation Methods

--- a/llmb-run/llmb_run.py
+++ b/llmb-run/llmb_run.py
@@ -573,16 +573,16 @@ def model_optimizations(model_overrides):
     return ' '.join(optimizations)
 
 def get_slurm_env_vars(config):
-    """Convert slurm config section to SBATCH_ environment variables."""
+    """Convert slurm config section to SLURM_ environment variables."""
     slurm_env = {}
     slurm_config = config.get('slurm', {})
     
     if slurm_config.get('account'):
-        slurm_env['SBATCH_ACCOUNT'] = str(slurm_config['account'])
+        slurm_env['SLURM_ACCOUNT'] = str(slurm_config['account'])
     if slurm_config.get('gpu_partition'):
-        slurm_env['SBATCH_PARTITION'] = str(slurm_config['gpu_partition'])
+        slurm_env['SLURM_PARTITION'] = str(slurm_config['gpu_partition'])
     if slurm_config.get('gpu_gres'):
-        slurm_env['SBATCH_GPUS_PER_NODE'] = str(slurm_config['gpu_gres'])
+        slurm_env['SLURM_GPUS_PER_NODE'] = str(slurm_config['gpu_gres'])
     
     return slurm_env
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
- llmb-run/README: update documentation to reflect SLURM env variable
- llmb-run/llmb_run: update SBATCH to SLURM env variable

<!-- Reference any issues closed by this PR with "closes #1234". -->
closes #5 

<!-- How and where this was tested. -->
Tested by modifying local installation of dgxc-benchmarking and re-executing llmb-run submission command.  Noted proper passing of `SLURM_GPUS_PER_NODE` setting.

<!-- Note: The pull request title will be included in the CHANGELOG. -->
