### PR TITLE
Fixed container image for nemotronh

### DIFF
--- a/nemotronh/metadata.yaml
+++ b/nemotronh/metadata.yaml
@@ -7,7 +7,7 @@ general:
 
 container:
   images: 
-    - 'nvcr.io/nvidia/nemo:25.04.01'
+    - 'nvcr.io#nvidia/nemo:25.04.01'
 
 setup:
   setup_script: 'setup.sh'


### PR DESCRIPTION
## Description
At the current state installation script tries to download from the dockerhub. This will fix the code to download the image from nvcr.io and brings it inline with nemotron image address
https://github.com/NVIDIA/dgxc-benchmarking/blob/main/nemotron/metadata.yaml#L10
