### PR TITLE
v25.12.02

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+## [v25.12.02] - 2026-02-11
+
+### Fixed
+  - Pin `uv` to `<=0.9.28` in `install.sh` to avoid strict parsing failures when installing pinned `nemo_run` commits with `uv 0.9.29+`.
+
 ## [v25.12.01] - 2026-02-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -541,6 +541,14 @@ Qwen3 requires internet access to fetch model configs, and may encounter Hugging
 ### Workaround
 Manually update the transformers version inside the container to >4.57.3. Expect this to be fixed in a future release.
 
+## 4. uv 0.9.29+ breaks all recipes that use nemo_run
+
+### Issue
+Nearly every recipe installs `nemo_run` and will fail with `uv` `0.9.29+` due to uv rejecting unknown fields in `pyproject.toml` files.
+
+### Workaround
+Run `./install.sh` from this release. It enforces `uv <=0.9.28`, which avoids the strict parser breakage.
+
 # Support
 
 Terminology used in these recipes is explained in the [Appendix](APPENDIX.md).

--- a/alternative_recipes/helm-charts/inference/llm-benchmarks/README.md
+++ b/alternative_recipes/helm-charts/inference/llm-benchmarks/README.md
@@ -1,5 +1,5 @@
 # GenAI Benchmarking Helm Chart (single node)
-Designed as a helm chart to work standalone on a K8s cluster, this helm chart can deploy any [vLLM compatible model](https://docs.vllm.ai/en/latest/models/supported_models.html), or [SGLang compatible model](https://docs.sglang.ai/supported_models/generative_models.html) and benchmark it on a kubernetes cluster using [Perf Analyzer](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/perf_benchmark/perf_analyzer.html).
+Designed as a helm chart to work standalone on a K8s cluster, this helm chart can deploy any [vLLM compatible model](https://docs.vllm.ai/en/latest/models/supported_models.html), or [SGLang compatible model](https://docs.sglang.io/supported_models/text_generation/generative_models.html) and benchmark it on a kubernetes cluster using [Perf Analyzer](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/perf_benchmark/perf_analyzer.html).
 
 ## Setting the `values.yaml` for the benchmark
 
@@ -95,5 +95,4 @@ ngc cf task create --name benchmark --helm-chart qdrlnbkss8u1/llm-benchmark-char
   }' \
 --gpu-specification H100:GPU.H100_1x
 ```
-
 


### PR DESCRIPTION
### Fixed
  - Pin `uv` to `<=0.9.28` in `install.sh` to avoid strict parsing failures when installing pinned `nemo_run` commits with `uv 0.9.29+`.

